### PR TITLE
Typo in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
   name='ztag',
   version='1.0.0',
   description='utility for transforming and annotating JSON scan data with additional metdata',
-  licsense="Apache License, Version 2.0",
+  license="Apache License, Version 2.0",
   long_description=open(os.path.join(here, 'README.md')).read(),
   classifiers=[
     "Programming Language :: Python",


### PR DESCRIPTION
Fixes `/usr/lib/python3.5/distutils/dist.py:261: UserWarning: Unknown distribution option: 'licsense'
  warnings.warn(msg)`.