### PR TITLE
Add SSH/v2 subprotocol & schema for use with X/SSH grabs

### DIFF
--- a/ztag/annotations/protocols.py
+++ b/ztag/annotations/protocols.py
@@ -15,6 +15,7 @@ PROTOCOLS = [
     (protocols.DNS, protocols.DNS.OPEN_RESOLVER, {"device_with_dns":{"tags":["dns",]}}),
     (protocols.UPNP, protocols.UPNP.DISCOVERY, {"device_with_upnp":{"tags":["upnp",]}}),
     (protocols.SSH, protocols.SSH.BANNER, {"device_with_ssh":{"tags":["ssh",]}}),
+    (protocols.SSH, protocols.SSH.V2, {"device_with_ssh":{"tags":["ssh",]}}),
     (protocols.TELNET, protocols.TELNET.BANNER, {"device_with_telnet":{"tags":["telnet",]}}),
     #(protocols.NTP, protocols.NTP.TIME, {"device_with_ntp":{"tags":["ntp",]}}),
     (protocols.IMAP, protocols.IMAP.STARTTLS, {"device_with_imap":{"tags":["imap",]}}),

--- a/ztag/annotations/protocols.py
+++ b/ztag/annotations/protocols.py
@@ -14,7 +14,6 @@ PROTOCOLS = [
     (protocols.HTTPS, protocols.HTTPS.TLS, {"device_with_https":{"tags":["https",]}}),
     (protocols.DNS, protocols.DNS.OPEN_RESOLVER, {"device_with_dns":{"tags":["dns",]}}),
     (protocols.UPNP, protocols.UPNP.DISCOVERY, {"device_with_upnp":{"tags":["upnp",]}}),
-    (protocols.SSH, protocols.SSH.BANNER, {"device_with_ssh":{"tags":["ssh",]}}),
     (protocols.SSH, protocols.SSH.V2, {"device_with_ssh":{"tags":["ssh",]}}),
     (protocols.TELNET, protocols.TELNET.BANNER, {"device_with_telnet":{"tags":["telnet",]}}),
     #(protocols.NTP, protocols.NTP.TIME, {"device_with_ntp":{"tags":["ntp",]}}),

--- a/ztag/devices/device_with_ssh.json
+++ b/ztag/devices/device_with_ssh.json
@@ -1,8 +1,13 @@
 {
     "22": {
         "ssh": {
-            "banner": {
-                "raw_banner": "SSH-1.99-Cisco-1.25\n", 
+            "v2": {
+                "banner": {
+                    "comment": "Debian-1uber3~13017.gbpf27c34",
+                    "raw": "SSH-2.0-OpenSSH_7.3p1 Debian-1uber3~13017.gbpf27c34",
+                    "software": "OpenSSH_7.3p1",
+                    "version": "2.0"
+                },
                 "metadata": {}
             }
         }

--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -572,14 +572,6 @@ golang_crypto_param = SubRecord({
 #    "metadata":local_metadata
 #})
 
-ztag_ssh_signature = SubRecord({
-    "parsed":SubRecord({
-        "algorithm":CensysString(),
-        "value":IndexedBinary(),
-    }),
-    "raw":IndexedBinary(),
-})
-
 ztag_ssh_v2 = SubRecord({
     "metadata":local_metadata,
     "timestamp":DateTime(),
@@ -669,7 +661,12 @@ ztag_ssh_v2 = SubRecord({
                 "ecdsa_public_key":ztag_ssh_ecdsa_public_key,
                 "ed25519_public_key":ztag_ed25519_public_key,
             }),
-            "signature":ztag_ssh_signature,
+            "signature":SubRecord({
+                "signature_algorithm":SubRecord({
+                    "name":String(),
+                }),
+                "value":IndexedBinary(),
+            }),
             "parse_error":String(),
             "extensions":SubRecord({
                 "permit_X11_forwarding":Boolean(),

--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -641,7 +641,7 @@ ztag_ssh_banner = SubRecord({
     }),
     "server_host_key":SubRecord({
         "raw":IndexedBinary(),
-        "algorithm":CensysString(),
+        "algorithm":String(),
         "fingerprint_sha256":HexString(),
         "rsa_public_key":ztag_rsa_params,
         "dsa_public_key":ztag_dsa_params,
@@ -652,19 +652,19 @@ ztag_ssh_banner = SubRecord({
             "key":SubRecord({
                 "raw":IndexedBinary(),
                 "fingerprint_sha256":HexString(),
-                "algorithm":CensysString(),
+                "algorithm":String(),
                 "rsa_public_key":ztag_rsa_params,
                 "dsa_public_key":ztag_dsa_params,
                 "ecdsa_public_key":ztag_ssh_ecdsa_public_key,
                 "ed25519_public_key":ztag_ed25519_public_key,
             }),
-            "serial":CensysString(),
+            "serial":String(),
             "cert_type":SubRecord({
                 "id":Unsigned32BitInteger(),
-                "name":CensysString(),
+                "name":String(),
             }),
-            "key_id":CensysString(),
-            "valid_principals":ListOf(CensysString()),
+            "key_id":String(),
+            "valid_principals":ListOf(String()),
             "validity":SubRecord({
                 "valid_after":DateTime(doc="Timestamp of when certificate is first valid. Timezone is UTC."),
                 "valid_before":DateTime(doc="Timestamp of when certificate expires. Timezone is UTC."),
@@ -674,7 +674,7 @@ ztag_ssh_banner = SubRecord({
             "signature_key":SubRecord({
                 "raw":IndexedBinary(),
                 "fingerprint_sha256":HexString(),
-                "algorithm":CensysString(),
+                "algorithm":String(),
                 "rsa_public_key":ztag_rsa_params,
                 "dsa_public_key":ztag_dsa_params,
                 "ecdsa_public_key":ztag_ssh_ecdsa_public_key,
@@ -684,20 +684,20 @@ ztag_ssh_banner = SubRecord({
             "parse_error":String(),
             "extensions":SubRecord({
                 "known":SubRecord({
-                    "permit_X11_forwarding":CensysString(),
-                    "permit_agent_forwarding":CensysString(),
-                    "permit_port_forwarding":CensysString(),
-                    "permit_pty":CensysString(),
-                    "permit_user_rc":CensysString(),
+                    "permit_X11_forwarding":String(),
+                    "permit_agent_forwarding":String(),
+                    "permit_port_forwarding":String(),
+                    "permit_pty":String(),
+                    "permit_user_rc":String(),
                 }),
-                "unknown":ListOf(CensysString()),
+                "unknown":ListOf(String()),
             }),
             "critical_options":SubRecord({
                 "known":SubRecord({
-                    "force_command":CensysString(),
-                    "source_address":CensysString(),
+                    "force_command":String(),
+                    "source_address":String(),
                 }),
-                "unknown":ListOf(CensysString()),
+                "unknown":ListOf(String()),
             })
         })
     }),

--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -580,7 +580,7 @@ ztag_ssh_signature = SubRecord({
     "raw":IndexedBinary(),
 })
 
-ztag_ssh_banner = SubRecord({
+ztag_ssh_v2 = SubRecord({
     "metadata":local_metadata,
     "timestamp":DateTime(),
     "banner":SubRecord({
@@ -856,7 +856,7 @@ ztag_schemas = [
     #("ztag_open_proxy", ztag_open_proxy),
     ("ztag_modbus", ztag_modbus),
     ("ztag_extended_random", ztag_extended_random),
-    ("ztag_ssh_banner", ztag_ssh_banner),
+    ("ztag_ssh_v2", ztag_ssh_v2),
     ("ztag_dns_lookup", ztag_dns_lookup),
     ("ztag_bacnet", ztag_bacnet),
     ("ztag_fox", ztag_fox),
@@ -1386,7 +1386,7 @@ ipv4_host = Record({
             }),
             Port(22):SubRecord({
                 "ssh":SubRecord({
-                    "banner": ztag_ssh_banner
+                    "v2": ztag_ssh_v2
                 }),
             }),
             Port(53):SubRecord({

--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -581,51 +581,46 @@ ztag_ssh_signature = SubRecord({
 })
 
 ztag_ssh_banner = SubRecord({
-    "protocol_version":String(),
-    "software_version":String(),
-    "comment":CensysString(),
     "metadata":local_metadata,
     "timestamp":DateTime(),
-    "server_id":SubRecord({
+    "banner":SubRecord({
         "raw":CensysString(),
         "version":String(),
         "software":CensysString(),
         "comment":CensysString(),
     }),
-    "server_key_exchange":SubRecord({
-        "cookie": Binary(),
-        "kex_algorithms":ListOf(CensysString()),
-        "host_key_algorithms":ListOf(CensysString()),
-        "client_to_server_ciphers":ListOf(CensysString()),
-        "server_to_client_ciphers":ListOf(CensysString()),
-        "client_to_server_macs":ListOf(CensysString()),
-        "server_to_client_macs":ListOf(CensysString()),
-        "client_to_server_compression":ListOf(CensysString()),
-        "server_to_client_compression":ListOf(CensysString()),
-        "client_to_server_languages":ListOf(CensysString()),
-        "server_to_client_languages":ListOf(CensysString()),
+    "support":SubRecord({
+        "kex_algorithms":ListOf(String()),
+        "host_key_algorithms":ListOf(String()),
         "first_kex_follows":Boolean(),
-        "reserved":Unsigned32BitInteger(),
-    }),
-    "userauth":ListOf(CensysString()),
-    "algorithm_selection":SubRecord({
-        "dh_kex_algorithm":CensysString(),
-        "host_key_algorithm":CensysString(),
-        "client_to_server_alg_group": SubRecord({
-            "cipher":CensysString(),
-            "mac":CensysString(),
-            "compression":CensysString(),
+        "client_to_server":SubRecord({
+            "ciphers":ListOf(String()),
+            "macs":ListOf(String()),
+            "compressions":ListOf(String()),
+            "languages":ListOf(String()),
         }),
-        "server_to_client_alg_group": SubRecord({
-            "cipher":CensysString(),
-            "mac":CensysString(),
-            "compression":CensysString(),
+        "server_to_client":SubRecord({
+            "ciphers":ListOf(String()),
+            "macs":ListOf(String()),
+            "compressions":ListOf(String()),
+            "languages":ListOf(String()),
+        }),
+    }),
+    "selected":SubRecord({
+        "kex_algorithm":String(),
+        "host_key_algorithm":String(),
+        "client_to_server": SubRecord({
+            "cipher":String(),
+            "mac":String(),
+            "compression":String(),
+        }),
+        "server_to_client": SubRecord({
+            "cipher":String(),
+            "mac":String(),
+            "compression":String(),
         }),
     }),
     "key_exchange": SubRecord({
-        "ed25519sha256_params": SubRecord({
-            "server_public": IndexedBinary(),
-        }),
         "ecdh_params": SubRecord({
             "server_public": SubRecord({
                 "x": golang_crypto_param,
@@ -635,13 +630,10 @@ ztag_ssh_banner = SubRecord({
         "dh_params": SubRecord({
             "prime": golang_crypto_param,
             "generator": golang_crypto_param,
-            "server_public": golang_crypto_param,
         }),
-        "server_signature":ztag_ssh_signature,
     }),
     "server_host_key":SubRecord({
-        "raw":IndexedBinary(),
-        "algorithm":String(),
+        "key_algorithm":String(),
         "fingerprint_sha256":HexString(),
         "rsa_public_key":ztag_rsa_params,
         "dsa_public_key":ztag_dsa_params,
@@ -659,7 +651,7 @@ ztag_ssh_banner = SubRecord({
                 "ed25519_public_key":ztag_ed25519_public_key,
             }),
             "serial":String(),
-            "cert_type":SubRecord({
+            "type":SubRecord({
                 "id":Unsigned32BitInteger(),
                 "name":String(),
             }),
@@ -670,11 +662,9 @@ ztag_ssh_banner = SubRecord({
                 "valid_before":DateTime(doc="Timestamp of when certificate expires. Timezone is UTC."),
                 "length":Signed64BitInteger(),
             }),
-            "reserved":IndexedBinary(),
             "signature_key":SubRecord({
-                "raw":IndexedBinary(),
                 "fingerprint_sha256":HexString(),
-                "algorithm":String(),
+                "key_algorithm":String(),
                 "rsa_public_key":ztag_rsa_params,
                 "dsa_public_key":ztag_dsa_params,
                 "ecdsa_public_key":ztag_ssh_ecdsa_public_key,
@@ -683,23 +673,19 @@ ztag_ssh_banner = SubRecord({
             "signature":ztag_ssh_signature,
             "parse_error":String(),
             "extensions":SubRecord({
-                "known":SubRecord({
-                    "permit_X11_forwarding":String(),
-                    "permit_agent_forwarding":String(),
-                    "permit_port_forwarding":String(),
-                    "permit_pty":String(),
-                    "permit_user_rc":String(),
-                }),
+                "permit_X11_forwarding":Boolean(),
+                "permit_agent_forwarding":Boolean(),
+                "permit_port_forwarding":Boolean(),
+                "permit_pty":Boolean(),
+                "permit_user_rc":Boolean(),
                 "unknown":ListOf(String()),
             }),
             "critical_options":SubRecord({
-                "known":SubRecord({
-                    "force_command":String(),
-                    "source_address":String(),
-                }),
+                "force_command":Boolean(),
+                "source_address":Boolean(),
                 "unknown":ListOf(String()),
-            })
-        })
+            }),
+        }),
     }),
 })
 

--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -622,77 +622,84 @@ ztag_ssh_banner = SubRecord({
             "compression":CensysString(),
         }),
     }),
-    "dh_key_exchange": SubRecord({
-        "params": SubRecord({
+    "key_exchange": SubRecord({
+        "ed25519sha256_params": SubRecord({
+            "server_public": IndexedBinary(),
+        }),
+        "ecdh_params": SubRecord({
+            "server_public": SubRecord({
+                "x": golang_crypto_param,
+                "y": golang_crypto_param,
+            }),
+        }),
+        "dh_params": SubRecord({
             "prime": golang_crypto_param,
             "generator": golang_crypto_param,
-            "client_public": golang_crypto_param,
-            "client_private": golang_crypto_param,
             "server_public": golang_crypto_param,
         }),
         "server_signature":ztag_ssh_signature,
-        "server_host_key":SubRecord({
-            "raw":IndexedBinary(),
-            "algorithm":CensysString(),
-            "fingerprint_sha256":HexString(),
-            "rsa_public_key":ztag_rsa_params,
-            "dsa_public_key":ztag_dsa_params,
-            "ecdsa_public_key":ztag_ssh_ecdsa_public_key,
-            "ed25519_public_key":ztag_ed25519_public_key,
-            "certkey_public_key":SubRecord({
-                "nonce":IndexedBinary(),
-                "key":SubRecord({
-                    "raw":IndexedBinary(),
-                    "fingerprint_sha256":HexString(),
-                    "algorithm":CensysString(),
-                    "rsa_public_key":ztag_rsa_params,
-                    "dsa_public_key":ztag_dsa_params,
-                    "ecdsa_public_key":ztag_ssh_ecdsa_public_key,
-                    "ed25519_public_key":ztag_ed25519_public_key,
+    }),
+    "server_host_key":SubRecord({
+        "raw":IndexedBinary(),
+        "algorithm":CensysString(),
+        "fingerprint_sha256":HexString(),
+        "rsa_public_key":ztag_rsa_params,
+        "dsa_public_key":ztag_dsa_params,
+        "ecdsa_public_key":ztag_ssh_ecdsa_public_key,
+        "ed25519_public_key":ztag_ed25519_public_key,
+        "certkey_public_key":SubRecord({
+            "nonce":IndexedBinary(),
+            "key":SubRecord({
+                "raw":IndexedBinary(),
+                "fingerprint_sha256":HexString(),
+                "algorithm":CensysString(),
+                "rsa_public_key":ztag_rsa_params,
+                "dsa_public_key":ztag_dsa_params,
+                "ecdsa_public_key":ztag_ssh_ecdsa_public_key,
+                "ed25519_public_key":ztag_ed25519_public_key,
+            }),
+            "serial":CensysString(),
+            "cert_type":SubRecord({
+                "id":Unsigned32BitInteger(),
+                "name":CensysString(),
+            }),
+            "key_id":CensysString(),
+            "valid_principals":ListOf(CensysString()),
+            "validity":SubRecord({
+                "valid_after":DateTime(doc="Timestamp of when certificate is first valid. Timezone is UTC."),
+                "valid_before":DateTime(doc="Timestamp of when certificate expires. Timezone is UTC."),
+                "length":Signed64BitInteger(),
+            }),
+            "reserved":IndexedBinary(),
+            "signature_key":SubRecord({
+                "raw":IndexedBinary(),
+                "fingerprint_sha256":HexString(),
+                "algorithm":CensysString(),
+                "rsa_public_key":ztag_rsa_params,
+                "dsa_public_key":ztag_dsa_params,
+                "ecdsa_public_key":ztag_ssh_ecdsa_public_key,
+                "ed25519_public_key":ztag_ed25519_public_key,
+            }),
+            "signature":ztag_ssh_signature,
+            "parse_error":String(),
+            "extensions":SubRecord({
+                "known":SubRecord({
+                    "permit_X11_forwarding":CensysString(),
+                    "permit_agent_forwarding":CensysString(),
+                    "permit_port_forwarding":CensysString(),
+                    "permit_pty":CensysString(),
+                    "permit_user_rc":CensysString(),
                 }),
-                "serial":CensysString(),
-                "cert_type":SubRecord({
-                    "id":Unsigned32BitInteger(),
-                    "name":CensysString(),
+                "unknown":ListOf(CensysString()),
+            }),
+            "critical_options":SubRecord({
+                "known":SubRecord({
+                    "force_command":CensysString(),
+                    "source_address":CensysString(),
                 }),
-                "key_id":CensysString(),
-                "valid_principals":ListOf(CensysString()),
-                "validity":SubRecord({
-                    "valid_after":DateTime(doc="Timestamp of when certificate is first valid. Timezone is UTC."),
-                    "valid_before":DateTime(doc="Timestamp of when certificate expires. Timezone is UTC."),
-                    "length":Signed64BitInteger(),
-                }),
-                "reserved":IndexedBinary(),
-                "signature_key":SubRecord({
-                    "raw":IndexedBinary(),
-                    "fingerprint_sha256":HexString(),
-                    "algorithm":CensysString(),
-                    "rsa_public_key":ztag_rsa_params,
-                    "dsa_public_key":ztag_dsa_params,
-                    "ecdsa_public_key":ztag_ssh_ecdsa_public_key,
-                    "ed25519_public_key":ztag_ed25519_public_key,
-                }),
-                "signature":ztag_ssh_signature,
-                "parse_error":String(),
-                "extensions":SubRecord({
-                    "known":SubRecord({
-                        "permit_X11_forwarding":CensysString(),
-                        "permit_agent_forwarding":CensysString(),
-                        "permit_port_forwarding":CensysString(),
-                        "permit_pty":CensysString(),
-                        "permit_user_rc":CensysString(),
-                    }),
-                    "unknown":ListOf(CensysString()),
-                }),
-                "critical_options":SubRecord({
-                    "known":SubRecord({
-                        "force_command":CensysString(),
-                        "source_address":CensysString(),
-                    }),
-                    "unknown":ListOf(CensysString()),
-                })
+                "unknown":ListOf(CensysString()),
             })
-        }),
+        })
     }),
 })
 

--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -642,7 +642,6 @@ ztag_ssh_v2 = SubRecord({
         "certkey_public_key":SubRecord({
             "nonce":IndexedBinary(),
             "key":SubRecord({
-                "raw":IndexedBinary(),
                 "fingerprint_sha256":HexString(),
                 "algorithm":String(),
                 "rsa_public_key":ztag_rsa_params,

--- a/ztag/transforms/__init__.py
+++ b/ztag/transforms/__init__.py
@@ -28,7 +28,7 @@ from pop3 import POP3STransform
 from s7 import S7Transform
 from smtp import SMTPStartTLSTransform
 from smtp import SMTPSTransform
-from ssh import SSHBannerTransform
+from ssh import SSHV2Transform
 from telnet import TelnetTransform
 from upnp import UPnPTransform
 from fox import NiagaraFoxTransform

--- a/ztag/transforms/ssh.py
+++ b/ztag/transforms/ssh.py
@@ -130,6 +130,17 @@ class SSHV2Transform(ZGrabTransform):
                 del_key(key, 'raw')
                 certkey_public_key['key'] = key
 
+            sig = certkey_public_key.get('signature')
+            if sig is not None:
+                formatted_sig = dict()
+                parsed = sig.get('parsed')
+                if parsed is not None:
+                    set_value(formatted_sig, 'value', parsed.get('value'))
+                    alg = dict()
+                    set_value(alg, 'name', parsed.get('algorithm'))
+                    set_value(formatted_sig, 'signature_algorithm', alg)
+                certkey_public_key['signature'] = formatted_sig
+
             set_value(host_key, 'certkey_public_key', certkey_public_key)
 
         set_value(out, 'server_host_key', host_key)

--- a/ztag/transforms/ssh.py
+++ b/ztag/transforms/ssh.py
@@ -3,9 +3,35 @@ from datetime import datetime
 from ztag.transform import ZGrabTransform, ZMapTransformOutput, Transformable
 from ztag import errors, protocols
 
+class SSHV2Transform(ZGrabTransform):
+    """Transforms ZGrab XSSH grabs for Censys."""
+
+    name = "ssh/sshv2"
+    port = None
+    protocol = protocols.SSH
+    subprotocol = protocols.SSH.V2
+
+    grab = Transformable(obj)
+    transformed = grab['data']['xssh'].resolve()
+
+    # TODO: rearrange per schema in https://docs.google.com/document/d/1M-4_WYM4-Z2lrbQTVtMtcSwGqsCX26xnm9XRt3jH_3s/edit
+
+    # move server_host_key up to top level (zgrab puts it inside key_exchange)
+    try:
+        grab['data']['xssh']['server_host_key'] = grab['data']['xssh']['key_exchange']['server_host_key']
+        del grab['data']['xssh']['key_exchange']['server_host_key']
+    except KeyError:
+        pass
+
+    if len(transformed) == 0:
+        raise errors.IgnoreObject("Empty [X]SSH protocol output dict")
+
+    zout = ZMapTransformOutput()
+    zout.transformed = transformed
+    return zout
+
 class SSHBannerTransform(ZGrabTransform):
-    """Transforms ZGrab SSH grabs for Censys.
-    Works with output from both the new XSSH grabber and the older SSH grabber."""
+    """Transforms ZGrab SSH grabs for Censys."""
 
     name = "ssh/banner"
     port = None
@@ -13,49 +39,23 @@ class SSHBannerTransform(ZGrabTransform):
     subprotocol = protocols.SSH.BANNER
 
     def _transform_object(self, obj):
-        grab = Transformable(obj)
+        sp = grab['data']['ssh']['server_protocol']
+        if sp.resolve() is None:
+            raise errors.IgnoreObject("No SSH grab data")
 
-        # At first, assume we have an XSSH grab and output it in its entirety:
-        transformed = grab['data']['xssh'].resolve()
-
-        if transformed is not None:
-            # If we have an XSSH grab, output certain fields as before for
-            # backward compatibility:
-            protocol_version = grab['data']['xssh']['server_id']['version'].resolve()
-            if protocol_version is not None:
-                transformed['protocol_version'] = protocol_version
-            software_version = grab['data']['xssh']['server_id']['software'].resolve()
-            if software_version is not None:
-                transformed['software_version'] = software_version
-            comment = grab['data']['xssh']['server_id']['comment'].resolve()
-            if comment is not None:
-                transformed['comment'] = comment
-            try:
-                grab['data']['xssh']['server_host_key'] = grab['data']['xssh']['key_exchange']['server_host_key']
-                del grab['data']['xssh']['key_exchange']['server_host_key']
-            except KeyError:
-                pass
-
-        else:
-            # This might be an old-style SSH grab. Process it just like we
-            # always have:
-            sp = grab['data']['ssh']['server_protocol']
-            if sp.resolve() is None:
-                raise errors.IgnoreObject("No [X]SSH grab data")
-
-            transformed = {}
-            raw_banner = sp['raw_banner'].resolve()
-            if raw_banner is not None:
-                transformed['raw_banner'] = raw_banner
-            protocol_version = sp['protocol_version'].resolve()
-            if protocol_version is not None:
-                transformed['protocol_version'] = protocol_version
-            software_version = sp['software_version'].resolve()
-            if software_version is not None:
-                transformed['software_version'] = software_version
-            comment = sp['comment'].resolve()
-            if comment is not None:
-                transformed['comment'] = comment
+        transformed = {}
+        raw_banner = sp['raw_banner'].resolve()
+        if raw_banner is not None:
+            transformed['raw_banner'] = raw_banner
+        protocol_version = sp['protocol_version'].resolve()
+        if protocol_version is not None:
+            transformed['protocol_version'] = protocol_version
+        software_version = sp['software_version'].resolve()
+        if software_version is not None:
+            transformed['software_version'] = software_version
+        comment = sp['comment'].resolve()
+        if comment is not None:
+            transformed['comment'] = comment
 
         if len(transformed) == 0:
             raise errors.IgnoreObject("Empty [X]SSH protocol output dict")

--- a/ztag/transforms/ssh.py
+++ b/ztag/transforms/ssh.py
@@ -31,11 +31,6 @@ class SSHBannerTransform(ZGrabTransform):
             if comment is not None:
                 transformed['comment'] = comment
             try:
-                del grab['data']['xssh']['key_exchange']['dh_params']['client_private']
-                del grab['data']['xssh']['key_exchange']['dh_params']['client_public']
-            except KeyError:
-                pass
-            try:
                 grab['data']['xssh']['server_host_key'] = grab['data']['xssh']['key_exchange']['server_host_key']
                 del grab['data']['xssh']['key_exchange']['server_host_key']
             except KeyError:

--- a/ztag/transforms/ssh.py
+++ b/ztag/transforms/ssh.py
@@ -30,6 +30,16 @@ class SSHBannerTransform(ZGrabTransform):
             comment = grab['data']['xssh']['server_id']['comment'].resolve()
             if comment is not None:
                 transformed['comment'] = comment
+            try:
+                del grab['data']['xssh']['key_exchange']['dh_params']['client_private']
+                del grab['data']['xssh']['key_exchange']['dh_params']['client_public']
+            except KeyError:
+                pass
+            try:
+                grab['data']['xssh']['server_host_key'] = grab['data']['xssh']['key_exchange']['server_host_key']
+                del grab['data']['xssh']['key_exchange']['server_host_key']
+            except KeyError:
+                pass
 
         else:
             # This might be an old-style SSH grab. Process it just like we

--- a/ztag/transforms/ssh.py
+++ b/ztag/transforms/ssh.py
@@ -3,6 +3,44 @@ from datetime import datetime
 from ztag.transform import ZGrabTransform, ZMapTransformOutput, Transformable
 from ztag import errors, protocols
 
+def set_value(dict, key, value):
+    """Set the given value for the given key in the given dictionary, iff the
+    value is not None and has a non-zero len (for objects with a length).
+    """
+    if value is None:
+        return
+    if hasattr(value, '__len__') and len(value) == 0:
+        return
+
+    dict[key] = value
+
+def rename_key(dict, old_key, new_key):
+    """Moves a value from old_key to new_key in the given dictionary.
+
+    No-op if old_key doesn't exist in the dictionary."""
+    try:
+        dict[new_key] = dict[old_key]
+        del dict[old_key]
+    except KeyError:
+        pass
+
+def del_key(dict, key):
+    """Deletes the given key from the given dictionary.
+
+    No-op if key doesn't exist in the dictionary."""
+    try:
+        del dict[key]
+    except KeyError:
+        pass
+
+def rewrite_known(dict):
+    known = dict.get('known')
+    if known is not None:
+        for key in known.keys():
+            dict[key] = True
+        del dict['known']
+    return dict
+
 class SSHV2Transform(ZGrabTransform):
     """Transforms ZGrab XSSH grabs for Censys."""
 
@@ -11,21 +49,89 @@ class SSHV2Transform(ZGrabTransform):
     protocol = protocols.SSH
     subprotocol = protocols.SSH.V2
 
-    grab = Transformable(obj)
-    transformed = grab['data']['xssh'].resolve()
+    def __init__(self, *args, **kwargs):
+        super(SSHV2Transform, self).__init__(*args, **kwargs)
 
-    # TODO: rearrange per schema in https://docs.google.com/document/d/1M-4_WYM4-Z2lrbQTVtMtcSwGqsCX26xnm9XRt3jH_3s/edit
+    def _transform_object(self, obj):
+        grab = Transformable(obj)['data']['xssh']
+        out = dict()
 
-    # move server_host_key up to top level (zgrab puts it inside key_exchange)
-    try:
-        grab['data']['xssh']['server_host_key'] = grab['data']['xssh']['key_exchange']['server_host_key']
-        del grab['data']['xssh']['key_exchange']['server_host_key']
-    except KeyError:
-        pass
+        # banner:
+        set_value(out, 'banner', grab['server_id'].resolve())
 
-    if len(transformed) == 0:
-        raise errors.IgnoreObject("Empty [X]SSH protocol output dict")
+        # support:
+        support = dict()
+        set_value(support, 'kex_algorithms', grab['server_key_exchange']['kex_algorithms'].resolve())
+        set_value(support, 'host_key_algorithms', grab['server_key_exchange']['host_key_algorithms'].resolve())
+        set_value(support, 'first_kex_follows', grab['server_key_exchange']['first_kex_follows'].resolve())
 
-    zout = ZMapTransformOutput()
-    zout.transformed = transformed
-    return zout
+        client_to_server = dict()
+        set_value(client_to_server, 'ciphers', grab['server_key_exchange']['client_to_server_ciphers'].resolve())
+        set_value(client_to_server, 'macs', grab['server_key_exchange']['client_to_server_macs'].resolve())
+        set_value(client_to_server, 'compressions', grab['server_key_exchange']['client_to_server_compression'].resolve())
+        set_value(client_to_server, 'languages', grab['server_key_exchange']['client_to_server_languages'].resolve())
+        set_value(support, 'client_to_server', client_to_server)
+
+        server_to_client = dict()
+        set_value(server_to_client, 'ciphers', grab['server_key_exchange']['server_to_client_ciphers'].resolve())
+        set_value(server_to_client, 'macs', grab['server_key_exchange']['server_to_client_macs'].resolve())
+        set_value(server_to_client, 'compressions', grab['server_key_exchange']['server_to_client_compression'].resolve())
+        set_value(server_to_client, 'languages', grab['server_key_exchange']['server_to_client_languages'].resolve())
+        set_value(support, 'server_to_client', server_to_client)
+
+        set_value(out, 'support', support)
+
+        # selected:
+        selected = grab['algorithm_selection'].resolve()
+        if selected is not None:
+            rename_key(selected, 'dh_kex_algorithm', 'kex_algorithm')
+            rename_key(selected, 'client_to_server_alg_group', 'client_to_server')
+            rename_key(selected, 'server_to_client_alg_group', 'server_to_client')
+        set_value(out, 'selected', selected)
+
+        # key_exchange:
+        key_exchange = dict()
+        set_value(key_exchange, 'ecdh_params', grab['key_exchange']['ecdh_params'].resolve())
+        set_value(key_exchange, 'dh_params', grab['key_exchange']['dh_params'].resolve())
+        try:
+            del key_exchange['dh_params']['server_public']
+        except KeyError:
+            pass
+        set_value(out, 'key_exchange', key_exchange)
+
+        # server_host_key:
+        host_key = dict()
+        for clone_key in ['fingerprint_sha256', 'rsa_public_key', 'dsa_public_key', 'ecdsa_public_key', 'ed25519_public_key']:
+            # a bunch of keys we just need to copy verbatim from the grab
+            set_value(host_key, clone_key, grab['key_exchange']['server_host_key'][clone_key].resolve())
+        set_value(host_key, 'key_algorithm', grab['key_exchange']['server_host_key']['algorithm'].resolve())
+
+        certkey_public_key = grab['key_exchange']['server_host_key']['certkey_public_key'].resolve()
+        if certkey_public_key is not None:
+            rename_key(certkey_public_key, 'cert_type', 'type')
+            del_key(certkey_public_key, 'reserved')
+
+            signature_key = certkey_public_key.get('signature_key')
+            if signature_key is not None:
+                del_key(signature_key, 'raw')
+                rename_key(signature_key, 'algorithm', 'key_algorithm')
+                certkey_public_key['signature_key'] = signature_key
+
+            # rewrite extensions and critical_options to maps of string -> bool:
+            extensions = certkey_public_key.get('extensions')
+            if extensions is not None:
+                certkey_public_key['extensions'] = rewrite_known(extensions)
+            critical_options = certkey_public_key.get('critical_options')
+            if critical_options is not None:
+                certkey_public_key['critical_options'] = rewrite_known(critical_options)
+
+            set_value(host_key, 'certkey_public_key', certkey_public_key)
+
+        set_value(out, 'server_host_key', host_key)
+
+        if len(out) == 0:
+            raise errors.IgnoreObject("Empty SSH protocol output dict")
+
+        zout = ZMapTransformOutput()
+        zout.transformed = out
+        return zout

--- a/ztag/transforms/ssh.py
+++ b/ztag/transforms/ssh.py
@@ -6,7 +6,7 @@ from ztag import errors, protocols
 class SSHV2Transform(ZGrabTransform):
     """Transforms ZGrab XSSH grabs for Censys."""
 
-    name = "ssh/sshv2"
+    name = "ssh/v2"
     port = None
     protocol = protocols.SSH
     subprotocol = protocols.SSH.V2

--- a/ztag/transforms/ssh.py
+++ b/ztag/transforms/ssh.py
@@ -29,37 +29,3 @@ class SSHV2Transform(ZGrabTransform):
     zout = ZMapTransformOutput()
     zout.transformed = transformed
     return zout
-
-class SSHBannerTransform(ZGrabTransform):
-    """Transforms ZGrab SSH grabs for Censys."""
-
-    name = "ssh/banner"
-    port = None
-    protocol = protocols.SSH
-    subprotocol = protocols.SSH.BANNER
-
-    def _transform_object(self, obj):
-        sp = grab['data']['ssh']['server_protocol']
-        if sp.resolve() is None:
-            raise errors.IgnoreObject("No SSH grab data")
-
-        transformed = {}
-        raw_banner = sp['raw_banner'].resolve()
-        if raw_banner is not None:
-            transformed['raw_banner'] = raw_banner
-        protocol_version = sp['protocol_version'].resolve()
-        if protocol_version is not None:
-            transformed['protocol_version'] = protocol_version
-        software_version = sp['software_version'].resolve()
-        if software_version is not None:
-            transformed['software_version'] = software_version
-        comment = sp['comment'].resolve()
-        if comment is not None:
-            transformed['comment'] = comment
-
-        if len(transformed) == 0:
-            raise errors.IgnoreObject("Empty [X]SSH protocol output dict")
-
-        zout = ZMapTransformOutput()
-        zout.transformed = transformed
-        return zout

--- a/ztag/transforms/ssh.py
+++ b/ztag/transforms/ssh.py
@@ -125,6 +125,11 @@ class SSHV2Transform(ZGrabTransform):
             if critical_options is not None:
                 certkey_public_key['critical_options'] = rewrite_known(critical_options)
 
+            key = certkey_public_key.get('key')
+            if key is not None:
+                del_key(key, 'raw')
+                certkey_public_key['key'] = key
+
             set_value(host_key, 'certkey_public_key', certkey_public_key)
 
         set_value(out, 'server_host_key', host_key)


### PR DESCRIPTION
This updates our SSH transform to work with [the new v2 subprotocol we defined](https://github.com/Censys/censys-definitions/pull/25) and output [the new schema we defined](https://docs.google.com/document/d/1M-4_WYM4-Z2lrbQTVtMtcSwGqsCX26xnm9XRt3jH_3s/edit). The old SSH/banner subprotocol has been completely removed.

This PR is compatible with the latest [ZGrab](https://github.com/zmap/zgrab) from `master` (currently https://github.com/zmap/zgrab/commit/4c4f01ee32a5b6340c1d3b8f5300502549672e5d).

ZTag usage for X/SSH scans will now be as follows: `ztag -P ssh -p 22 -S v2`.

Example input (`grab`) and output (`tagged`) is available at https://gist.github.com/cdzombak/2987d220fcfd938b67526192e5cba5dd.