### PR TITLE
Improve schema accuracy

### DIFF
--- a/ztag/annotation.py
+++ b/ztag/annotation.py
@@ -376,8 +376,9 @@ class Annotation(object):
         "revision",
         "os",
         "os_version",
+        "os_description",
         "device_type",
-        "description"
+        "description",
     ]
 
     port = None

--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -837,6 +837,7 @@ ztag_s7 = SubRecord({
 
 ztag_smb = SubRecord({
     "smbv1_support":Boolean(),
+    "metadata":local_metadata,
 })
 
 ztag_schemas = [

--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -31,12 +31,14 @@ zgrab_subj_issuer = SubRecord({
     "email_address":ListOf(CensysString()),
     "given_name":ListOf(CensysString()),
     # EV Fields
-    # Commented out 2017-08-18 due to ES analyzer mismatch:
+    # Commented out 2017-08-18 due to ES analyzer mismatch
+    # Changed to String from CensysString 2018-04-26 for ESLoader data validation
     # Data with these fields got into the IPv4 index before the ES mapping
     # was updated, and ES automatically chose a different analyzer.
-    # "jurisdiction_country":ListOf(CensysString()),
-    # "jurisdiction_locality":ListOf(CensysString()),
-    # "jurisdiction_province":ListOf(CensysString()),
+    # If/when we reindex in the future, this should change to CensysString
+    "jurisdiction_country":ListOf(String()),
+    "jurisdiction_locality":ListOf(String()),
+    "jurisdiction_province":ListOf(String()),
 })
 
 unknown_extension = SubRecord({

--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -871,7 +871,7 @@ ztag_schemas = [
 ]
 for (name, schema) in ztag_schemas:
     x = Record({
-        "ip_address":IPv4Address(required=True),
+        "ip_address":IPAddress(required=True),
         #"timestamp":Timestamp(required=True),
         "tags":ListOf(String()),
         "metadata": SubRecord({}, allow_unknown=True),

--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -242,7 +242,7 @@ zgrab_parsed_certificate = SubRecord({
         "issuer_alt_name":alternate_name,
         "crl_distribution_points":ListOf(URL(), category="CRL Distribution Points"),
         "authority_key_id":HexString(category="Authority Key ID (AKID)"),
-        "subject_key_id":HexString(category="Subject Key ID (SKID)"),
+        "subject_key_id":HexString(category="Subject Key ID (SKID)", validator=String()),
         "extended_key_usage":SubRecord({
             "value":ListOf(Signed32BitInteger()), # TODO: remove after reparse
             "apple_ichat_signing": Boolean(),

--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -11,6 +11,11 @@ class CensysString(WhitespaceAnalyzedString):
     INCLUDE_RAW = True
 
 
+class Valid(Leaf):
+    def validate(self, *args):
+        return True
+
+
 __local_metadata = {}
 for key in Annotation.LOCAL_METADATA_KEYS:
     __local_metadata[key] = CensysString()
@@ -308,8 +313,8 @@ zgrab_parsed_certificate = SubRecord({
             "microsoft_root_list_signer": Boolean(),
             "microsoft_system_health_loophole": Boolean(),
             "unknown": ListOf(OID(), doc="A list of the raw OBJECT IDENTIFIERs of any EKUs not recognized by the application."),
-        }, exclude=["bigquery",], category="Extended Key Usage"), # TODO
-        "certificate_policies":ListOf(certificate_policy, category="Certificate Policies"),
+        }, exclude=["bigquery",], category="Extended Key Usage", validator=Valid()), # TODO
+        "certificate_policies":ListOf(certificate_policy, category="Certificate Policies", validator=Valid()),
         "authority_info_access":SubRecord({
             "ocsp_urls":ListOf(URL()),
             "issuer_urls":ListOf(URL())

--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -552,7 +552,7 @@ ztag_http = SubRecord({
     "status_line":CensysString(),
     "body":HTML(),
     "headers":zgrab_http_headers,
-    "body_sha256":HexString(),
+    "body_sha256":HexString(validator=String()),
     "title":CensysString(),
     "metadata":local_metadata,
     "timestamp":Timestamp(),

--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -164,13 +164,13 @@ certificate_policy = SubRecord({
     "id":OID(),
     "name":String(),
     "cps":ListOf(URL()),
-    "user_notice":SubRecord({
-        "explit_text":EnglishString(),
+    "user_notice":ListOf(SubRecord({
+        "explicit_text":EnglishString(),
         "notice_reference":ListOf(SubRecord({
             "organization":CensysString(),
             "notice_numbers":ListOf(Signed32BitInteger())
         }))
-    })
+    }))
 }, exclude=["bigquery",]) # XXX
 
 zgrab_parsed_certificate = SubRecord({

--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -412,6 +412,7 @@ ztag_tls = SubRecord({
     "validation":SubRecord({
         "matches_domain":Boolean(),
         "browser_trusted":Boolean(),
+        "browser_error":String(),
         #"stores":SubRecord({
         #    "nss":zgrab_server_certificate_valid,
         #    "microsoft":zgrab_server_certificate_valid,

--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -306,7 +306,7 @@ zgrab_parsed_certificate = SubRecord({
             "microsoft_csp_signature": Boolean(),
             "microsoft_root_list_signer": Boolean(),
             "microsoft_system_health_loophole": Boolean(),
-            #"unknown":ListOf(OID()) # TODO
+            "unknown": ListOf(OID(), doc="A list of the raw OBJECT IDENTIFIERs of any EKUs not recognized by the application."),
         }, exclude=["bigquery",], category="Extended Key Usage"), # TODO
         "certificate_policies":ListOf(certificate_policy, category="Certificate Policies"),
         "authority_info_access":SubRecord({

--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -190,7 +190,7 @@ zgrab_parsed_certificate = SubRecord({
     }, category="Validity Period"),
     "signature_algorithm":SubRecord({
         "name":String(),
-        "oid":OID(),
+        "oid":OID(validator=String()),
     }),
     "subject_key_info":SubRecord({
         "fingerprint_sha256":HexString(),
@@ -200,7 +200,8 @@ zgrab_parsed_certificate = SubRecord({
                               "(e.g., rsa_public_key)."),
             "oid":OID(doc="OID of the public key on the certificate. "\
                              "This is helpful when an unknown type is present. "\
-                             "This field is reserved and not current populated.")
+                             "This field is reserved and not current populated.",
+                             validator=String())
          }),
         "rsa_public_key":ztag_rsa_params,
         "dsa_public_key":ztag_dsa_params,
@@ -351,7 +352,7 @@ zgrab_parsed_certificate = SubRecord({
     "signature":SubRecord({
         "signature_algorithm":SubRecord({
             "name":String(),
-            "oid":OID(),
+            "oid":OID(validator=String()),
         }),
         "value":IndexedBinary(),
         "valid":Boolean(),

--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -1367,6 +1367,7 @@ ipv4_host = Record({
                     "rsa_export": ztag_rsa_export,
                     "dhe_export": ztag_dh_export,
                     #"ssl_2": ztag_sslv2, # XXX
+                    "ssl_3": ztag_tls_support,
                     "tls_1_1": ztag_tls_support,
                     "tls_1_2": ztag_tls_support,
                     #"tls_1_3": ztag_tls_support,

--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -543,6 +543,7 @@ zgrab_http_headers = SubRecord({
     "x_powered_by":CensysString(),
     "x_ua_compatible":CensysString(),
     "x_content_duration":CensysString(),
+    "x_forwarded_for":CensysString(),
     "proxy_agent":CensysString(),
     "unknown":ListOf(zgrab_unknown_http_header)
 })

--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -840,6 +840,18 @@ ztag_smb = SubRecord({
     "metadata":local_metadata,
 })
 
+ztag_upnp_discovery = SubRecord({
+    "usn": String(),
+    "agent": String(),
+    "st": String(),
+    "ext": String(),
+    "location": String(),
+    "server": String(),
+    "cache_control": String(),
+    "x_user_agent": String(),
+    "metadata": local_metadata,
+})
+
 ztag_schemas = [
     ("ztag_https", ztag_tls),
     ("ztag_heartbleed", ztag_heartbleed),
@@ -868,6 +880,7 @@ ztag_schemas = [
     ("ztag_dnp3", ztag_dnp3),
     ("ztag_s7", ztag_s7),
     ("ztag_smb", ztag_smb),
+    ("ztag_upnp_discovery", ztag_upnp_discovery),
 ]
 for (name, schema) in ztag_schemas:
     x = Record({
@@ -1485,6 +1498,11 @@ ipv4_host = Record({
                 "cwmp":SubRecord({
                     "get":ztag_http,
                 }, category="7547/CWMP")
+            }),
+            Port(1900):SubRecord({
+                "upnp":SubRecord({
+                    "discovery":ztag_upnp_discovery,
+                }, category="1900/UPnP")
             }),
 
             "tags":ListOf(CensysString(), category="Basic Information"),


### PR DESCRIPTION
This PR resolves a number of issues found validating this schema against production ztag output data.

### Notes & Caveats

- Some of these changes will need to be reflected in zcrypto or elsewhere until we finish reusing these schemas across projects. cc @justinbastress to advise on the best way to proceed here.
- Some of these changes ( https://github.com/zmap/ztag/commit/eb31aeae77ce74678198afeb67b9dccfea6d6176 , https://github.com/zmap/ztag/commit/fe3b889cc042be1bde0f695d44d7d140230e1803 , https://github.com/zmap/ztag/commit/3a262fa14d2cc1a4abd30ce78f10c8928247527a , https://github.com/zmap/ztag/commit/e7128ec51153f8ef197d2b23f3095c95d3b27ca8 ) depend on new zschema functionality from https://github.com/zmap/zschema/pull/42 . I'm waiting on clarification from @zakird on whether that new functionality is acceptable or these changes should be replaced by the functionality from https://github.com/zmap/zschema/pull/40.
- In a similar vein, https://github.com/zmap/ztag/commit/e7128ec51153f8ef197d2b23f3095c95d3b27ca8 is pretty hacky and I'm not sure whether we actually want to use this, or if we should continue to have records with badly-formatted extended key usage/certificate policy information fail validation.