### PR TITLE
ztag: omitempty from transforms

### DIFF
--- a/ztag/transforms/mssql.py
+++ b/ztag/transforms/mssql.py
@@ -29,7 +29,7 @@ class MSSQLTransform(ZGrab2Transform):
                 zout.transformed[f] = results[f]
 
         # If we don't have a root encrypt_mode, fall back to prelogin_options
-        if zout.transformed.get("encrypt_mode") is not None:
+        if zout.transformed.get("encrypt_mode") is None:
             if results.get("prelogin_options") is not None:
                 self.load_prelogin_options(results["prelogin_options"], zout)
 

--- a/ztag/transforms/mssql.py
+++ b/ztag/transforms/mssql.py
@@ -13,7 +13,7 @@ class MSSQLTransform(ZGrab2Transform):
         super(MSSQLTransform, self).__init__(*args, **kwargs)
 
     def load_prelogin_options(self, prelogin, zout):
-        if "encrypt_mode" in prelogin:
+        if prelogin.get("encrypt_mode") is not None:
             zout.transformed["encrypt_mode"] = prelogin["encrypt_mode"]
 
     def _transform_object(self, obj):
@@ -22,12 +22,15 @@ class MSSQLTransform(ZGrab2Transform):
         if not results:
             return zout
 
-        # Version is required, ignore this record if it isn't present.
-        zout.transformed["version"] = results["version"]
+        to_copy = ["version", "instance_name", "encrypt_mode"]
 
-        if "instance_name" in results:
-            zout.transformed["instance_name"] = results["instance_name"]
-        if "prelogin_options" in results:
-            self.load_prelogin_options(results["prelogin_options"], zout)
+        for f in to_copy:
+            if results.get(f) is not None:
+                zout.transformed[f] = results[f]
+
+        # If we don't have a root encrypt_mode, fall back to prelogin_options
+        if zout.transformed.get("encrypt_mode") is not None:
+            if results.get("prelogin_options") is not None:
+                self.load_prelogin_options(results["prelogin_options"], zout)
 
         return zout

--- a/ztag/transforms/mysql.py
+++ b/ztag/transforms/mysql.py
@@ -18,17 +18,15 @@ class MySQLTransform(ZGrab2Transform):
         if not results:
             return zout
 
-        if "protocol_version" in results:
-            zout.transformed["protocol_version"] = results["protocol_version"]
-        if "server_version" in results:
-            zout.transformed["server_version"] = results["server_version"]
-        if "capability_flags" in results:
-            zout.transformed["capability_flags"] = results["capability_flags"]
-        if "status_flags" in results:
-            zout.transformed["status_flags"] = results["status_flags"]
-        if "error_code" in results:
-            zout.transformed["error_code"] = results["error_code"]
-        if "error_message" in results:
-            zout.transformed["error_message"] = self.clean_banner(results["error_message"])
+        to_copy = ["protocol_version", "server_version", "capability_flags",
+                   "status_flags", "error_code", "error_message"]
+        for f in to_copy:
+            if results.get(f) is not None:
+                zout.transformed[f] = results[f]
+
+        to_clean = ["error_message"]
+        for f in to_clean:
+            if f in zout.transformed:
+                zout.transformed[f] = self.clean_banner(zout.transformed[f])
 
         return zout

--- a/ztag/transforms/oracle.py
+++ b/ztag/transforms/oracle.py
@@ -28,11 +28,11 @@ class OracleTransform(ZGrab2Transform):
 
         # Otherwise, just copy everything from handshake into the root.
         for k, v in results["handshake"].items():
-            if v is not None:
-                if k == "refuse_error_raw":
-                    v = self.clean_banner(v)
-                elif k == "refuse_error":
-                    v = self.clean_descriptor(v)
-                zout.transformed[k] = v
+            if v is None: continue
+            if k == "refuse_error_raw":
+                v = self.clean_banner(v)
+            elif k == "refuse_error":
+                v = self.clean_descriptor(v)
+            zout.transformed[k] = v
 
         return zout

--- a/ztag/transforms/oracle.py
+++ b/ztag/transforms/oracle.py
@@ -17,8 +17,7 @@ class OracleTransform(ZGrab2Transform):
         return [{
             "key": entry["key"],
             "value": self.clean_banner(entry["value"])
-        } for entry in desc ]
-
+        } for entry in desc]
 
     def _transform_object(self, obj):
         # There shouldn't be a TLS object in this scan.
@@ -29,10 +28,11 @@ class OracleTransform(ZGrab2Transform):
 
         # Otherwise, just copy everything from handshake into the root.
         for k, v in results["handshake"].items():
-            if k == "refuse_error_raw":
-                v = self.clean_banner(v)
-            elif k == "refuse_error":
-                v = self.clean_descriptor(v)
-            zout.transformed[k] = v
+            if v is not None:
+                if k == "refuse_error_raw":
+                    v = self.clean_banner(v)
+                elif k == "refuse_error":
+                    v = self.clean_descriptor(v)
+                zout.transformed[k] = v
 
         return zout

--- a/ztag/transforms/postgres.py
+++ b/ztag/transforms/postgres.py
@@ -21,18 +21,27 @@ class PostgresTransform(ZGrab2Transform):
         if not results:
             return zout
 
-        if "supported_versions" in results:
-            zout.transformed["supported_versions"] = self.clean_banner(results["supported_versions"])
-        if "protocol_error" in results:
-            zout.transformed["protocol_error"] = self.clean_error(results["protocol_error"])
-        if "startup_error" in results:
-            zout.transformed["startup_error"] = self.clean_error(results["startup_error"])
+        to_copy = ["supported_versions", "protocol_error", "startup_error",
+                   "backend_key_data"]
+
+        for f in to_copy:
+            if results.get(f) is not None:
+                zout.transformed[f] = results[f]
+
+        to_clean = ["supported_versions", "protocol_error", "startup_error"]
+        for f in to_clean:
+            if f in zout.transformed:
+                zout.transformed[f] = self.clean_banner(zout.transformed[f])
+
         if "is_ssl" in results:
             zout.transformed["is_ssl"] = bool(results.get("is_ssl", False))
-        if "authentication_mode" in results:
+
+        if results.get("authentication_mode") is not None:
             zout.transformed["authentication_mode"] = [
                 x["mode"] for x in results["authentication_mode"]
             ]
-        if "backend_key_data" in results:
+
+        if results.get("backend_key_data") is not None:
             zout.transformed["backend_key_data"] = results["backend_key_data"]
+
         return zout


### PR DESCRIPTION
If a scanner returns "None" for an optional field, the transforms now omit it.

This should now be moot, since the scanners are fixed, but if such errors are introduced in the future, they will not get past the transforms.