### PR TITLE
Revert esloader workarounds in master

### DIFF
--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -25,7 +25,7 @@ def _recurse_object(v):
     # Attempt to retain attributes (required/doc/etc)
     from copy import deepcopy
 
-    if type(v) == zschema.leaves.String or type(v) == zschema.leaves.HexString:
+    if type(v) == zschema.leaves.String:
         # TODO; Find the right way to copy over all of v's attributes but just
         # change its type to a CensysString()
         return CensysString()
@@ -557,8 +557,7 @@ def ztag_zgrab2_transformed(service, results):
 # The oracle ztag transform is a plain copy of the "handshake" field.
 ztag_oracle = ztag_zgrab2_transformed(service="Oracle", results=zgrab2_oracle.oracle_scan_response["result"]["handshake"] | remove_strings)
 
-# FIXME: Workaround 2018/05/22 -- match previous schema
-ztag_oracle["tls"] = ztag_tls_type(doc="The TLS handshake with the server (if applicable).") | remove_strings
+ztag_oracle["tls"] = ztag_tls_type(doc="The TLS handshake with the server (if applicable).")
 
 ztag_mssql = ztag_zgrab2_transformed(service="MSSQL", results=SubRecord({
     "version": CensysString(doc="The MSSQL version returned by the server in "
@@ -573,7 +572,7 @@ ztag_mssql = ztag_zgrab2_transformed(service="MSSQL", results=SubRecord({
                              "for details."),
     "tls": ztag_tls_type(doc="The TLS handshake with the server (for "
                              "non-encrypted connections, this used only "
-                             "for the authentication phase).") | remove_strings, # FIXME: Workaround 2018/05/22 -- match previous schema
+                             "for the authentication phase).")
 }))
 
 ztag_mysql = ztag_zgrab2_transformed(service="MySQL", results=SubRecord({
@@ -586,7 +585,7 @@ ztag_mysql = ztag_zgrab2_transformed(service="MySQL", results=SubRecord({
     "error_message": zgrab2.mysql.mysql_scan_response["result"]["error_message"] | remove_strings,
     "tls": ztag_tls_type(doc="If the server allows upgrading the "
                              "session to use TLS, this is the log of "
-                             "the handshake.") | remove_strings, # FIXME: Workaround 2018/05/22 -- match previous schema
+                             "the handshake.")
 }))
 
 ztag_postgres = ztag_zgrab2_transformed(service="PostgreSQL", results=SubRecord({
@@ -602,7 +601,7 @@ ztag_postgres = ztag_zgrab2_transformed(service="PostgreSQL", results=SubRecord(
     "backend_key_data": zgrab2.postgres.postgres_key_data | remove_strings,
     "tls": ztag_tls_type(doc="If the server allows upgrading the "
                              "session to use TLS, this is the log of "
-                             "the handshake.") | remove_strings, # FIXME: Workaround 2018/05/22 -- match previous schema
+                             "the handshake.")
 }))
 
 


### PR DESCRIPTION
These were added in #118/#119.

They turned out to be unnecessary, since the problem was not old schema mismatching new schema, but rather auto-detected types mismatching the new schema.