### PR TITLE
copy mysql.error_id in ztag transform

### DIFF
--- a/ztag/transforms/mysql.py
+++ b/ztag/transforms/mysql.py
@@ -19,7 +19,7 @@ class MySQLTransform(ZGrab2Transform):
             return zout
 
         to_copy = ["protocol_version", "server_version", "capability_flags",
-                   "status_flags", "error_code", "error_message"]
+                   "status_flags", "error_code", "error_message", "error_id"]
         for f in to_copy:
             if results.get(f) is not None:
                 zout.transformed[f] = results[f]


### PR DESCRIPTION
This is already in the schema, but I don't know if that schema was deployed to ES yet...so before merging this to stable, we would need to do that.

Having said that, this is probably lower-priority.