### PR TITLE
Fix postgres transform

### DIFF
--- a/ztag/transforms/postgres.py
+++ b/ztag/transforms/postgres.py
@@ -28,8 +28,13 @@ class PostgresTransform(ZGrab2Transform):
             if results.get(f) is not None:
                 zout.transformed[f] = results[f]
 
-        to_clean = ["supported_versions", "protocol_error", "startup_error"]
-        for f in to_clean:
+        to_clean_error = ["protocol_error", "startup_error"]
+        for f in to_clean_error:
+            if f in zout.transformed:
+                zout.transformed[f] = self.clean_error(zout.transformed[f])
+
+        to_clean_banner = ["supported_versions"]
+        for f in to_clean_banner:
             if f in zout.transformed:
                 zout.transformed[f] = self.clean_banner(zout.transformed[f])
 


### PR DESCRIPTION
`startup_error` and `protocol_error` are dicts, not strings, so `clean_banner()` will not work on them.

I had written the `clean_error()` before, but neglected to actually use it. As a result, records with these were either throwing and the whole record was omitted, or the fields were just absent.

