### PR TITLE
Create IPP Transform and Schema

### DIFF
--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -604,6 +604,19 @@ ztag_postgres = ztag_zgrab2_transformed(service="PostgreSQL", results=SubRecord(
                              "the handshake.")
 }))
 
+ztag_ipp = ztag_zgrab2_transformed(service="IPP", results=SubRecord({
+    "version_major": zgrab2.ipp.ipp_scan_response["result"]["version_major"],
+    "version_minor": zgrab2.ipp.ipp_scan_response["result"]["version_minor"],
+    "version_string": zgrab2.ipp.ipp_scan_response["result"]["version_string"],
+    "cups_version": zgrab2.ipp.ipp_scan_response["result"]["cups_version"],
+    "attributes": zgrab2.ipp.ipp_scan_response["result"]["attributes"],
+    "attr_ipp_versions": zgrab2.ipp.ipp_scan_response["result"]["attr_ipp_versions"],
+    "attr_cups_version": zgrab2.ipp.ipp_scan_response["result"]["attr_cups_version"],
+    "attr_printer_uris": zgrab2.ipp.ipp_scan_response["result"]["attr_printer_uris"],
+    "tls": ztag_tls_type(doc="If the server allows upgrading the "
+                             "session to use TLS, this is the log of "
+                             "the handshake."),
+}))
 
 ztag_schemas = [
     ("ztag_https", ztag_tls),
@@ -636,6 +649,7 @@ ztag_schemas = [
     ("ztag_upnp_discovery", ztag_upnp_discovery),
     ("ztag_oracle", ztag_oracle),
     ("ztag_mssql", ztag_mssql),
+    ("ztag_ipp", ztag_ipp),
 ]
 for (name, schema) in ztag_schemas:
     x = Record({
@@ -1278,6 +1292,11 @@ ipv4_host = Record({
                 "postgres": SubRecord({
                     "banner": ztag_postgres,
                 }, category="5432/Postgres"),
+            }),
+            Port(631): SubRecord({
+                "ipp": SubRecord({
+                    "banner": ztag_ipp,
+                }, category="631/IPP"),
             }),
             "tags":ListOf(CensysString(), category="Basic Information"),
             "metadata":zdb_metadata,

--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -616,9 +616,6 @@ ztag_ipp = ztag_zgrab2_transformed(service="IPP", results=SubRecord({
     "tls": ztag_tls_type(doc="If the server allows upgrading the "
                              "session to use TLS, this is the log of "
                              "the handshake."),
-    "global_metadata": SubRecord({}),
-    "local_metadata": SubRecord({}),
-    "timestamp": Timestamp(required=True),
 }))
 
 ztag_schemas = [

--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -616,6 +616,9 @@ ztag_ipp = ztag_zgrab2_transformed(service="IPP", results=SubRecord({
     "tls": ztag_tls_type(doc="If the server allows upgrading the "
                              "session to use TLS, this is the log of "
                              "the handshake."),
+    "global_metadata": SubRecord({}),
+    "local_metadata": SubRecord({}),
+    "timestamp": Timestamp(required=True),
 }))
 
 ztag_schemas = [

--- a/ztag/transforms/__init__.py
+++ b/ztag/transforms/__init__.py
@@ -39,3 +39,4 @@ from oracle import OracleTransform
 from postgres import PostgresTransform
 from mssql import MSSQLTransform
 from mysql import MySQLTransform
+from ipp import IPPTransform

--- a/ztag/transforms/ipp.py
+++ b/ztag/transforms/ipp.py
@@ -1,0 +1,32 @@
+from ztag.transform import ZGrab2Transform
+from ztag import protocols
+
+
+class IPPTransform(ZGrab2Transform):
+
+    name = "ipp/banner"
+    port = 631
+    protocol = protocols.IPP
+    subprotocol = protocols.IPP.BANNER
+
+    def __init__(self, *args, **kwargs):
+        super(IPPTransform, self).__init__(*args, **kwargs)
+
+    def _transform_object(self, obj):
+        zout = super(IPPTransform, self)._transform_object(obj)
+        results = self.get_scan_results(obj)
+        if not results:
+            return zout
+
+        to_copy = ["version_major", "version_minor", "version_string", "cups_version", "attributes", "attr_cups_version", "attr_ipp_versions", "attr_printer_uris", "tls"]
+
+        for f in to_copy:
+            if results.get(f) is not None:
+                zout.transformed[f] = results[f]
+
+        to_clean = []
+        for f in to_clean:
+            if f in zout.transformed:
+                zout.transformed[f] = self.clean_banner(zout.transformed[f])
+
+        return zout

--- a/ztag/transforms/ipp.py
+++ b/ztag/transforms/ipp.py
@@ -18,7 +18,7 @@ class IPPTransform(ZGrab2Transform):
         if not results:
             return zout
 
-        to_copy = ["version_major", "version_minor", "version_string", "cups_version", "attributes", "attr_cups_version", "attr_ipp_versions", "attr_printer_uris", "tls"]
+        to_copy = ["version_major", "version_minor", "version_string", "cups_version", "attributes", "attr_cups_version", "attr_ipp_versions", "attr_printer_uris"]
 
         for f in to_copy:
             if results.get(f) is not None:


### PR DESCRIPTION
Adds an identity transform for IPP protocol.
Specifies schema for IPP results.

Note: some errors are currently created by the inclusion of (global/local)_metadata and timestamp fields in IPP ztag output.