### PR TITLE
Lessens ES Invalid Record Errors [CEN-566]

### DIFF
--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -659,7 +659,7 @@ ztag_lookup_dmarc = SubRecord({
 
 ztag_lookup_axfr = SubRecord({
     "servers":ListOf(SubRecord({
-        "server":String(),
+        "server":IPAddress(),
         "status":String(),
         "name":FQDN(),
         "support":Boolean(),

--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -239,7 +239,7 @@ zgrab_http_headers = SubRecord({
     "public_key_pins":CensysString(),
     "refresh":CensysString(),
     # Currently misindexed in IPv4 schema
-    #"referer":CensysString(),
+    "referer":CensysString(),
     "retry_after":CensysString(),
     "server":CensysString(),
     "set_cookie":CensysString(),
@@ -262,6 +262,7 @@ zgrab_http_headers = SubRecord({
     "x_ua_compatible":CensysString(),
     "x_content_duration":CensysString(),
     "x_forwarded_for":CensysString(),
+    "x_real_ip":CensysString(),
     "proxy_agent":CensysString(),
     "unknown":ListOf(zgrab_unknown_http_header)
 })
@@ -658,10 +659,13 @@ ztag_lookup_dmarc = SubRecord({
 
 ztag_lookup_axfr = SubRecord({
     "servers":ListOf(SubRecord({
+        "server":String,
+        "status":String,
         "name":FQDN(),
         "support":Boolean(),
         "error":CensysString(),
         "records":ListOf(SubRecord({
+            "class":String(),
             "name":FQDN(),
             "type":String(),
             "data":CensysString(),
@@ -1301,6 +1305,7 @@ website = Record({
                     "dhe": ztag_dh,
                     "rsa_export": ztag_rsa_export,
                     "dhe_export": ztag_dh_export,
+                    "ssl_3": ztag_tls_support,
                     "tls_1_1": ztag_tls_support,
                     "tls_1_2": ztag_tls_support,
                     "ecdhe": ztag_ecdh,

--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -659,8 +659,8 @@ ztag_lookup_dmarc = SubRecord({
 
 ztag_lookup_axfr = SubRecord({
     "servers":ListOf(SubRecord({
-        "server":String,
-        "status":String,
+        "server":String(),
+        "status":String(),
         "name":FQDN(),
         "support":Boolean(),
         "error":CensysString(),


### PR DESCRIPTION
Adds fields which are occurring in live results to their appropriate schemas, so that the ElasticSearch validation check passes.

These fixes should greatly reduce the volume of errors, but will not prevent everything.

Further work needs to be done in pipeline to log full invalid records once these changes are made.

Note: The invalid timestamp issue referenced in CEN-566 (https://censysio.atlassian.net/browse/CEN-566) should be resolved by my earlier change to zcrypto's timestamp clamping.