### PR TITLE
Remove pypy-5.4.1 from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: python
 
 python:
   - "2.7"
-  - "pypy-5.4.1"
 
 install:
   - pip install -r dev-requirements.txt


### PR DESCRIPTION
Running the Travis CI suite against PyPy is [consistently failing][ss]; here's an [example failure][f].

It looks like we've just been ignoring and merging, so if we're OK with not running against PyPy, let's just remove it from Travis CI.

If we're _not OK_ with these failing tests, and _do_ want to verify behavior against PyPy, then we can redirect this PR to fixing up the test suite.

[ss]: https://www.dropbox.com/s/raxz6naqgopkw31/Screenshot%202018-07-30%2008.40.44.png?raw=1
[f]: https://travis-ci.org/zmap/ztag/jobs/408529485