### PR TITLE
zgrab2 transform: don't throw on empty tls

### DIFF
--- a/ztag/transform.py
+++ b/ztag/transform.py
@@ -1,7 +1,6 @@
 import json
 import re
 
-from ztag import errors
 from ztag.errors import IgnoreObject
 
 
@@ -377,7 +376,7 @@ class ZGrab2Transform(ZMapTransform):
                     tls_out, tls_certs = HTTPSTransform.make_tls_obj(tls_record)
                     out.transformed["tls"] = tls_out
                     out.certificates = out.certificates + tls_certs
-                except errors.IgnoreObject:
+                except IgnoreObject:
                     # Just because the TLS field fails doesn't mean we want to throw away the rest
                     # of the object.
                     # TODO: It may still be useful to log these, though.

--- a/ztag/transform.py
+++ b/ztag/transform.py
@@ -1,6 +1,7 @@
 import json
 import re
 
+from ztag import errors
 from ztag.errors import IgnoreObject
 
 
@@ -372,9 +373,15 @@ class ZGrab2Transform(ZMapTransform):
                                      "handshake_log")
             if tls_record is not None:
                 from ztag.transforms import HTTPSTransform
-                tls_out, tls_certs = HTTPSTransform.make_tls_obj(tls_record)
-                out.transformed["tls"] = tls_out
-                out.certificates = out.certificates + tls_certs
+                try:
+                    tls_out, tls_certs = HTTPSTransform.make_tls_obj(tls_record)
+                    out.transformed["tls"] = tls_out
+                    out.certificates = out.certificates + tls_certs
+                except errors.IgnoreObject:
+                    # Just because the TLS field fails doesn't mean we want to throw away the rest
+                    # of the object.
+                    # TODO: It may still be useful to log these, though.
+                    pass
 
         return out
 


### PR DESCRIPTION
One side effect of re-using the HTTPS TLS processing code in the generic zgrab2 transform is if the resultant output TLS is empty, it throws `errors.IgnoreObject` -- which may be reasonable in the case of HTTPS, but is not valid in general for zgrab2 tasks, where partial TLS handshakes may still have useful information in the rest of the scan.

Specifically, we are getting a huge number of these for mysql -- even though a wealth of valuable host information available is collected prior to the TLS handshake even being attempted.