### PR TITLE
Fix deadlock in pubsub callback msg reschedule

### DIFF
--- a/ztag/test/updater_test.py
+++ b/ztag/test/updater_test.py
@@ -25,7 +25,7 @@ class UpdaterTestCase(unittest.TestCase):
             row = UpdateRow(
                 skipped=skipped,
                 handled=handled,
-                time=float(i) / 100.0,
+                updated_at=float(i) / 100.0,
                 prev=updater.prev)
 
             if not updater.prev or (row.time - updater.prev.time) >= updater.frequency:


### PR DESCRIPTION
Calling back into the pubsub API from the done callback to reschedule failed messages was resulting in the same thread attempting the acquire the same mutex twice. This results in deadlock (?!?!?).

Fixed by passing the list of failed messages back to the main thread to reschedule.

Main thread wakes up every 10 seconds to reschedule failed messages. 5 failures on an individual message results in flagging the pubsub threads to exit on next done callback and raising an exception. 

Also, reclaimed `time` as a global module name :)