### PR TITLE
Don't hide internal errors in IgnoreObject exceptions

### DIFF
--- a/ztag/decoders/decoders.py
+++ b/ztag/decoders/decoders.py
@@ -12,13 +12,7 @@ class JSONDecoder(Decoder):
         self.logger = logger
 
     def decode(self, s):
-        try:
-            return json.loads(s)
-        except ValueError as e:
-            self.logger.error(str(e))
-            self.logger.error(s.strip())
-            raise errors.IgnoreObject(e)
-
+        return json.loads(s)
 
 class TSVDecoder(Decoder):
 

--- a/ztag/errors.py
+++ b/ztag/errors.py
@@ -4,9 +4,10 @@ class InvalidTag(Exception):
 
 class IgnoreObject(Exception):
 
-    def __init__(self, original_exception=None, *args, **kwargs):
+    def __init__(self, original_exception=None, trback=None, *args, **kwargs):
         super(Exception, self).__init__(*args, **kwargs)
         self.original_exception = original_exception
+        self.trback = trback
 
 
 class UnknownProtocol(Exception):

--- a/ztag/stream.py
+++ b/ztag/stream.py
@@ -115,6 +115,8 @@ class Stream(object):
                 if self.logger:
                     self.logger.debug(e.original_exception)
                     self.logger.trace(obj)
+                    if e.trback:
+                        self.logger.warn(e.trback)
                 skipped += 1
                 continue
         self.outgoing.cleanup()

--- a/ztag/transform.py
+++ b/ztag/transform.py
@@ -63,7 +63,9 @@ class Transform(object):
         try:
             return self._transform_object(obj)
         except (KeyError, TypeError, IndexError) as e:
-            raise IgnoreObject(original_exception=e)
+            import traceback
+            exc_info = traceback.format_exc()
+            raise IgnoreObject(e, exc_info)
 
     def _transform_object(self, obj):
         raise NotImplementedError

--- a/ztag/transforms/https.py
+++ b/ztag/transforms/https.py
@@ -15,6 +15,8 @@ class HTTPSTransform(ZGrabTransform):
         super(HTTPSTransform, self).__init__(*args, **kwargs)
 
     def _transform_object(self, obj):
+        if 'tls' not in obj['data']:
+            raise errors.IgnoreObject("Not a TLS response")
         tls = obj['data']['tls']
         out, certificates = HTTPSTransform.make_tls_obj(tls)
         zout = ZMapTransformOutput()


### PR DESCRIPTION
Forked from https://github.com/zmap/ztag/pull/161

