### PR TITLE
add HTTPS.GET transform, add get to ztag_https schema

### DIFF
--- a/ztag/schema.py
+++ b/ztag/schema.py
@@ -1162,6 +1162,7 @@ ipv4_host = Record({
             Port(443):SubRecord({
                 "https":SubRecord({
                     "tls":ztag_tls,
+                    "get":ztag_http,
                     "heartbleed":ztag_heartbleed,
                     "dhe": ztag_dh,
                     "rsa_export": ztag_rsa_export,

--- a/ztag/transforms/__init__.py
+++ b/ztag/transforms/__init__.py
@@ -7,6 +7,7 @@ from http import HTTPTransform
 from http import HTTPWWWTransform
 
 from https import HTTPSTransform
+from https import HTTPSGetTransform
 from https import HTTPSWWWTransform
 from https import HeartbleedTransform
 from https import RSAExportTransform

--- a/ztag/transforms/https.py
+++ b/ztag/transforms/https.py
@@ -2,6 +2,17 @@ from ztag.transform import ZGrabTransform, ZMapTransformOutput
 from ztag import protocols, errors
 from ztag.transform import Transformable
 from ztag.errors import IgnoreObject
+from http import HTTPTransform
+
+
+class HTTPSGetTransform(HTTPTransform):
+    name = "https/generic"
+    port = None
+    protocol = protocols.HTTPS
+    subprotocol = protocols.HTTPS.GET
+
+    def __init__(self, *args, **kwargs):
+        super(HTTPSGetTransform, self).__init__(*args, **kwargs)
 
 
 class HTTPSTransform(ZGrabTransform):


### PR DESCRIPTION
Test:
`dig citibank.com A +short | ../zgrab/zgrab --http-max-size=64 --http=/ --tls --http-max-redirects=5 --port=443 --timeout=5 --follow-localhost-redirects=False --metadata-file=zgrab-metadata.json | tee zgrab-https.json | PYTHONPATH=. python -m ztag -P https -S get -p 443 --metadata-file=ztag-metadata.json > https-ztag.json`

Then check that https-ztag.json looks right.